### PR TITLE
fix: support complex and nested inner types

### DIFF
--- a/src/__tests__/__snapshots__/markdown-helpers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/markdown-helpers.spec.ts.snap
@@ -1,5 +1,287 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`markdown-helpers rawTypeToTypeInformation() should map a Promise types correctly 1`] = `
+Object {
+  "collection": false,
+  "innerTypes": Array [
+    Object {
+      "collection": false,
+      "type": "T",
+    },
+  ],
+  "type": "Promise",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a complex Promise types correctly 1`] = `
+Object {
+  "collection": false,
+  "innerTypes": Array [
+    Object {
+      "collection": false,
+      "type": Array [
+        Object {
+          "collection": false,
+          "type": "T",
+        },
+        Object {
+          "collection": false,
+          "type": "A",
+        },
+      ],
+    },
+  ],
+  "type": "Promise",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a function return type + param types correctly 1`] = `
+Object {
+  "collection": false,
+  "parameters": Array [
+    Object {
+      "collection": false,
+      "type": "P1",
+    },
+    Object {
+      "collection": false,
+      "type": "P2",
+    },
+  ],
+  "returns": Object {
+    "collection": false,
+    "type": "R",
+  },
+  "type": "Function",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a function return type correctly 1`] = `
+Object {
+  "collection": false,
+  "parameters": Array [],
+  "returns": Object {
+    "collection": false,
+    "type": "R",
+  },
+  "type": "Function",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a function with complex return type + complex param types correctly 1`] = `
+Object {
+  "collection": false,
+  "parameters": Array [
+    Object {
+      "collection": false,
+      "innerTypes": Array [
+        Object {
+          "collection": false,
+          "type": "InnerP1",
+        },
+        Object {
+          "collection": true,
+          "type": "AnotherInnerP1",
+        },
+      ],
+      "type": "P1",
+    },
+    Object {
+      "collection": false,
+      "innerTypes": Array [
+        Object {
+          "collection": true,
+          "type": Array [
+            Object {
+              "collection": false,
+              "type": "InnerP2",
+            },
+            Object {
+              "collection": false,
+              "innerTypes": Array [
+                Object {
+                  "collection": false,
+                  "type": "SuperDeepP2",
+                },
+                Object {
+                  "collection": false,
+                  "type": "EvenDeeperP2",
+                },
+              ],
+              "type": "AnotherInnerP2",
+            },
+          ],
+        },
+      ],
+      "type": "P2",
+    },
+  ],
+  "returns": Object {
+    "collection": false,
+    "innerTypes": Array [
+      Object {
+        "collection": false,
+        "type": "Foo",
+      },
+    ],
+    "type": "R",
+  },
+  "type": "Function",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a nested Function types correctly 1`] = `
+Object {
+  "collection": false,
+  "innerTypes": Array [
+    Object {
+      "collection": false,
+      "type": Array [
+        Object {
+          "collection": false,
+          "type": "T",
+        },
+        Object {
+          "collection": true,
+          "parameters": Array [],
+          "returns": Object {
+            "collection": true,
+            "type": "A",
+          },
+          "type": "Function",
+        },
+      ],
+    },
+  ],
+  "type": "Promise",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a nested Promise types correctly 1`] = `
+Object {
+  "collection": false,
+  "innerTypes": Array [
+    Object {
+      "collection": false,
+      "type": Array [
+        Object {
+          "collection": false,
+          "type": "T",
+        },
+        Object {
+          "collection": false,
+          "innerTypes": Array [
+            Object {
+              "collection": false,
+              "type": "A",
+            },
+          ],
+          "type": "Promise",
+        },
+      ],
+    },
+  ],
+  "type": "Promise",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a nested complex Promise types correctly 1`] = `
+Object {
+  "collection": false,
+  "innerTypes": Array [
+    Object {
+      "collection": false,
+      "type": Array [
+        Object {
+          "collection": false,
+          "type": "T",
+        },
+        Object {
+          "collection": true,
+          "innerTypes": Array [
+            Object {
+              "collection": true,
+              "type": "A",
+            },
+          ],
+          "type": "Promise",
+        },
+      ],
+    },
+  ],
+  "type": "Promise",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a nested complex Promise types correctly 2`] = `
+Object {
+  "collection": false,
+  "innerTypes": Array [
+    Object {
+      "collection": false,
+      "type": Array [
+        Object {
+          "collection": false,
+          "type": "T",
+        },
+        Object {
+          "collection": true,
+          "innerTypes": Array [
+            Object {
+              "collection": true,
+              "type": "A",
+            },
+          ],
+          "type": "Promise",
+        },
+      ],
+    },
+  ],
+  "type": "Promise",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a primitive types correctly 1`] = `
+Object {
+  "collection": false,
+  "type": "Boolean",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map a wrapped collection type correctly 1`] = `
+Object {
+  "collection": false,
+  "innerTypes": Array [
+    Object {
+      "collection": true,
+      "type": Array [
+        Object {
+          "collection": false,
+          "type": "T",
+        },
+        Object {
+          "collection": false,
+          "parameters": Array [],
+          "returns": Object {
+            "collection": true,
+            "type": "A",
+          },
+          "type": "Function",
+        },
+      ],
+    },
+  ],
+  "type": "Promise",
+}
+`;
+
+exports[`markdown-helpers rawTypeToTypeInformation() should map an unknown types correctly 1`] = `
+Object {
+  "collection": false,
+  "type": "MyType",
+}
+`;
+
 exports[`markdown-helpers safelyJoinTokens snapshots should be correct for basic-paragraph 1`] = `"This is just a basic paragraph.  It has multiple sentences and natural soft breaks."`;
 
 exports[`markdown-helpers safelyJoinTokens snapshots should be correct for blockquotes 1`] = `

--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import MarkdownIt from 'markdown-it';
 
-import { safelyJoinTokens, extractStringEnum } from '../markdown-helpers';
+import { safelyJoinTokens, extractStringEnum, rawTypeToTypeInformation } from '../markdown-helpers';
 
 describe('markdown-helpers', () => {
   describe('safelyJoinTokens', () => {
@@ -84,6 +84,64 @@ describe('markdown-helpers', () => {
       expect(values[0].value).toBe('a');
       expect(values[1].value).toBe('b');
       expect(values[2].value).toBe('c');
+    });
+  });
+
+  describe('rawTypeToTypeInformation()', () => {
+    it('should map a primitive types correctly', () => {
+      expect(rawTypeToTypeInformation('Boolean', '', null)).toMatchSnapshot();
+    });
+
+    it('should map an unknown types correctly', () => {
+      expect(rawTypeToTypeInformation('MyType', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a Promise types correctly', () => {
+      expect(rawTypeToTypeInformation('Promise<T>', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a complex Promise types correctly', () => {
+      expect(rawTypeToTypeInformation('Promise<T | A>', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a nested Promise types correctly', () => {
+      expect(rawTypeToTypeInformation('Promise<T | Promise<A>>', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a nested complex Promise types correctly', () => {
+      expect(rawTypeToTypeInformation('Promise<T | Promise<A[]>[]>', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a nested complex Promise types correctly', () => {
+      expect(rawTypeToTypeInformation('Promise<T | Promise<A[]>[]>', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a nested Function types correctly', () => {
+      expect(rawTypeToTypeInformation('Promise<T | Function<A[]>[]>', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a wrapped collection type correctly', () => {
+      expect(
+        rawTypeToTypeInformation('Promise<(T | Function<A[]>)[]>', '', null),
+      ).toMatchSnapshot();
+    });
+
+    it('should map a function return type correctly', () => {
+      expect(rawTypeToTypeInformation('Function<R>', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a function return type + param types correctly', () => {
+      expect(rawTypeToTypeInformation('Function<P1, P2, R>', '', null)).toMatchSnapshot();
+    });
+
+    it('should map a function with complex return type + complex param types correctly', () => {
+      expect(
+        rawTypeToTypeInformation(
+          'Function<P1<InnerP1, AnotherInnerP1[]>, P2<(InnerP2 | AnotherInnerP2<SuperDeepP2, EvenDeeperP2>)[]>, R<Foo>>',
+          '',
+          null,
+        ),
+      ).toMatchSnapshot();
     });
   });
 });


### PR DESCRIPTION
This PR adds support for really complex inner types.  We currently support simple things like `Promise<T>` or `Function<A, B>` but if you gave it something fun like

```
Function<P1<InnerP1, AnotherInnerP1[]>, P2<(InnerP2 | AnotherInnerP2<SuperDeepP2, EvenDeeperP2>)[]>, R<Foo>>
```

It would just give up and cry in a corner.  This was because we were using things like `.split(',')` and regexps to get the inner type.  Unfortunately regexps have no concept of depth (you can't write a parser with regexps).  So now we go token by token and understand depth to correctly handle these complicated structures.

This PR comes with a bunch of tests which validate that this logic works as expected 👍 