### PR TITLE
fix: allow normal quotes as well as oxford commas

### DIFF
--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -62,6 +62,15 @@ describe('markdown-helpers', () => {
       expect(values[2].value).toBe('z');
     });
 
+    it('should extract an enum of the format "can be x, y, or z"', () => {
+      const values = extractStringEnum('Can be `x`, `y`, or `z`')!;
+      expect(values).not.toBe(null);
+      expect(values).toHaveLength(3);
+      expect(values[0].value).toBe('x');
+      expect(values[1].value).toBe('y');
+      expect(values[2].value).toBe('z');
+    });
+
     it('should extract an enum of the format "values include a', () => {
       const values = extractStringEnum('Values include `a`')!;
       expect(values).not.toBe(null);

--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -38,61 +38,122 @@ describe('markdown-helpers', () => {
       expect(extractStringEnum('wassup')).toBe(null);
     });
 
-    it('should extract an enum of the format "can be x"', () => {
-      const values = extractStringEnum('Can be `x`')!;
-      expect(values).not.toBe(null);
-      expect(values).toHaveLength(1);
-      expect(values[0].value).toBe('x');
+    describe('with single quotes', () => {
+      it('should extract an enum of the format "can be x"', () => {
+        const values = extractStringEnum('Can be `x`')!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(1);
+        expect(values[0].value).toBe('x');
+      });
+
+      it('should extract an enum of the format "can be x or y"', () => {
+        const values = extractStringEnum('Can be `x` or `y`')!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(2);
+        expect(values[0].value).toBe('x');
+        expect(values[1].value).toBe('y');
+      });
+
+      it('should extract an enum of the format "can be x, y or z"', () => {
+        const values = extractStringEnum('Can be `x`, `y` or `z`')!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(3);
+        expect(values[0].value).toBe('x');
+        expect(values[1].value).toBe('y');
+        expect(values[2].value).toBe('z');
+      });
+
+      it('should extract an enum of the format "can be x, y, or z"', () => {
+        const values = extractStringEnum('Can be `x`, `y`, or `z`')!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(3);
+        expect(values[0].value).toBe('x');
+        expect(values[1].value).toBe('y');
+        expect(values[2].value).toBe('z');
+      });
+
+      it('should extract an enum of the format "values include a', () => {
+        const values = extractStringEnum('Values include `a`')!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(1);
+        expect(values[0].value).toBe('a');
+      });
+
+      it('should extract an enum of the format "values include a and b', () => {
+        const values = extractStringEnum('Values include `a` and `b`')!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(2);
+        expect(values[0].value).toBe('a');
+        expect(values[1].value).toBe('b');
+      });
+
+      it('should extract an enum of the format "values include a, b and c', () => {
+        const values = extractStringEnum('Values include `a`, `b` and `c`')!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(3);
+        expect(values[0].value).toBe('a');
+        expect(values[1].value).toBe('b');
+        expect(values[2].value).toBe('c');
+      });
     });
 
-    it('should extract an enum of the format "can be x or y"', () => {
-      const values = extractStringEnum('Can be `x` or `y`')!;
-      expect(values).not.toBe(null);
-      expect(values).toHaveLength(2);
-      expect(values[0].value).toBe('x');
-      expect(values[1].value).toBe('y');
-    });
+    describe('with backticks', () => {
+      it('should extract an enum of the format "can be x"', () => {
+        const values = extractStringEnum(`Can be 'x'`)!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(1);
+        expect(values[0].value).toBe('x');
+      });
 
-    it('should extract an enum of the format "can be x, y or z"', () => {
-      const values = extractStringEnum('Can be `x`, `y` or `z`')!;
-      expect(values).not.toBe(null);
-      expect(values).toHaveLength(3);
-      expect(values[0].value).toBe('x');
-      expect(values[1].value).toBe('y');
-      expect(values[2].value).toBe('z');
-    });
+      it('should extract an enum of the format "can be x or y"', () => {
+        const values = extractStringEnum(`Can be 'x' or 'y'`)!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(2);
+        expect(values[0].value).toBe('x');
+        expect(values[1].value).toBe('y');
+      });
 
-    it('should extract an enum of the format "can be x, y, or z"', () => {
-      const values = extractStringEnum('Can be `x`, `y`, or `z`')!;
-      expect(values).not.toBe(null);
-      expect(values).toHaveLength(3);
-      expect(values[0].value).toBe('x');
-      expect(values[1].value).toBe('y');
-      expect(values[2].value).toBe('z');
-    });
+      it('should extract an enum of the format "can be x, y or z"', () => {
+        const values = extractStringEnum(`Can be 'x', 'y' or 'z'`)!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(3);
+        expect(values[0].value).toBe('x');
+        expect(values[1].value).toBe('y');
+        expect(values[2].value).toBe('z');
+      });
 
-    it('should extract an enum of the format "values include a', () => {
-      const values = extractStringEnum('Values include `a`')!;
-      expect(values).not.toBe(null);
-      expect(values).toHaveLength(1);
-      expect(values[0].value).toBe('a');
-    });
+      it('should extract an enum of the format "can be x, y, or z"', () => {
+        const values = extractStringEnum(`Can be 'x', 'y', or 'z'`)!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(3);
+        expect(values[0].value).toBe('x');
+        expect(values[1].value).toBe('y');
+        expect(values[2].value).toBe('z');
+      });
 
-    it('should extract an enum of the format "values include a and b', () => {
-      const values = extractStringEnum('Values include `a` and `b`')!;
-      expect(values).not.toBe(null);
-      expect(values).toHaveLength(2);
-      expect(values[0].value).toBe('a');
-      expect(values[1].value).toBe('b');
-    });
+      it('should extract an enum of the format "values include a', () => {
+        const values = extractStringEnum(`Values include 'a'`)!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(1);
+        expect(values[0].value).toBe('a');
+      });
 
-    it('should extract an enum of the format "values include a, b and c', () => {
-      const values = extractStringEnum('Values include `a`, `b` and `c`')!;
-      expect(values).not.toBe(null);
-      expect(values).toHaveLength(3);
-      expect(values[0].value).toBe('a');
-      expect(values[1].value).toBe('b');
-      expect(values[2].value).toBe('c');
+      it('should extract an enum of the format "values include a and b', () => {
+        const values = extractStringEnum(`Values include 'a' and 'b'`)!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(2);
+        expect(values[0].value).toBe('a');
+        expect(values[1].value).toBe('b');
+      });
+
+      it('should extract an enum of the format "values include a, b and c', () => {
+        const values = extractStringEnum(`Values include 'a', 'b' and 'c'`)!;
+        expect(values).not.toBe(null);
+        expect(values).toHaveLength(3);
+        expect(values[0].value).toBe('a');
+        expect(values[1].value).toBe('b');
+        expect(values[2].value).toBe('c');
+      });
     });
   });
 

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -327,7 +327,7 @@ export const extractStringEnum = (description: string): PossibleStringValue[] | 
   const inlineMatch = inlineValuesPattern.exec(description);
   if (inlineMatch) {
     const valueString = inlineMatch[1];
-    const valuePattern = /`([a-zA-Z-]+)`/g;
+    const valuePattern = /[`|']([a-zA-Z-]+)[`|']/g;
     let value = valuePattern.exec(valueString);
 
     while (value) {

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -323,7 +323,7 @@ export enum StripReturnTypeBehavior {
 export const extractStringEnum = (description: string): PossibleStringValue[] | null => {
   const possibleValues: PossibleStringValue[] = [];
 
-  const inlineValuesPattern = /(?:can be|values include) ((?:(?:`[a-zA-Z-]+`)(?:, ))*(?:`[a-zA-Z-]+`)?(?: (?:or|and) `[a-zA-Z-]+`)?)/i;
+  const inlineValuesPattern = /(?:can be|values include) ((?:(?:[`|'][a-zA-Z-]+[`|'])(?:(, | )?))*(?:(?:or|and) [`|'][a-zA-Z-]+[`|'])?)/i;
   const inlineMatch = inlineValuesPattern.exec(description);
   if (inlineMatch) {
     const valueString = inlineMatch[1];


### PR DESCRIPTION
This PR allows for string literals to use both backticks and normal quotes, as well as for users to optionally use oxford commas in specifying the last string literal.

Before, only the following worked:
```
Can be `record-until-full`, `record-continuously`, `record-as-much-as-possible` or `trace-to-console`.
```

With this change, all of the following now work:
```
Can be `record-until-full`, `record-continuously`, `record-as-much-as-possible` or `trace-to-console`.
```
```
Can be 'record-until-full', 'record-continuously', 'record-as-much-as-possible' or 'trace-to-console'.
```
```
Can be 'record-until-full', 'record-continuously', 'record-as-much-as-possible', or 'trace-to-console'.
```

To produce:
```
    recording_mode?: ('record-until-full' | 'record-continuously' | 'record-as-much-as-possible' | 'trace-to-console');
```

cc @MarshallOfSound 