### PR TITLE
feat: expose OS/stability tags in the API structure

### DIFF
--- a/src/DocsParser.ts
+++ b/src/DocsParser.ts
@@ -254,6 +254,7 @@ export class DocsParser {
         name: typedKey.key,
         description: typedKey.description,
         required: typedKey.required,
+        additionalTags: typedKey.additionalTags,
         ...typedKey.type,
       })),
     };

--- a/src/ParsedDocumentation.ts
+++ b/src/ParsedDocumentation.ts
@@ -1,3 +1,12 @@
+export enum DocumentationTag {
+  OS_MACOS = 'os_macos',
+  OS_MAS = 'os_mas',
+  OS_WINDOWS = 'os_windows',
+  OS_LINUX = 'os_linux',
+  STABILITY_EXPERIMENTAL = 'stability_experimental',
+  STABILITY_DEPRECATED = 'stability_deprecated',
+  AVAILABILITY_READONLY = 'availability_readonly',
+}
 export declare type PossibleStringValue = {
   value: string;
   description: string;
@@ -43,6 +52,7 @@ export declare type EventParameterDocumentation = {
 export declare type DocumentationBlock = {
   name: string;
   description: string;
+  additionalTags: DocumentationTag[];
 };
 export declare type MethodDocumentationBlock = DocumentationBlock & {
   signature: string;

--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -2,9 +2,43 @@ import * as fs from 'fs';
 import * as path from 'path';
 import MarkdownIt from 'markdown-it';
 
-import { safelyJoinTokens, extractStringEnum, rawTypeToTypeInformation } from '../markdown-helpers';
+import {
+  safelyJoinTokens,
+  extractStringEnum,
+  rawTypeToTypeInformation,
+  parseHeadingTags,
+} from '../markdown-helpers';
+import { DocumentationTag } from '../ParsedDocumentation';
 
 describe('markdown-helpers', () => {
+  describe('parseHeadingTags', () => {
+    it('should return an empty array for null input', () => {
+      expect(parseHeadingTags(null)).toEqual([]);
+    });
+
+    it('should return an empty array if there are no tags in the input', () => {
+      expect(parseHeadingTags('String thing no tags')).toEqual([]);
+    });
+
+    it('should return a list of tags if there is one tag', () => {
+      expect(parseHeadingTags(' _macOS_')).toEqual([DocumentationTag.OS_MACOS]);
+    });
+
+    it('should return a list of tags if there are multiple tags', () => {
+      expect(parseHeadingTags(' _macOS_ _Windows_ _Experimental_')).toEqual([
+        DocumentationTag.OS_MACOS,
+        DocumentationTag.OS_WINDOWS,
+        DocumentationTag.STABILITY_EXPERIMENTAL,
+      ]);
+    });
+
+    it('should throw an error if there is a tag not on the whitelist', () => {
+      expect(() => parseHeadingTags(' _Awesome_')).toThrowErrorMatchingInlineSnapshot(
+        `"heading tags must be from the whitelist: [\\"macOS\\",\\"mas\\",\\"Windows\\",\\"Linux\\",\\"Experimental\\",\\"Deprecated\\",\\"Readonly\\"]: expected [ Array(7) ] to include 'Awesome'"`,
+      );
+    });
+  });
+
   describe('safelyJoinTokens', () => {
     it('should join no tokens to an empty string', () => {
       expect(safelyJoinTokens([])).toBe('');


### PR DESCRIPTION
This exposes a new key `additionalTags` on every API structure (properties, events, methods, structure keys, etc.) for the tags we put on the API in `electron/electron.

These tags look like

```md
### myMethod() _macOS_
```

The resultant JSON looks like this

![image](https://user-images.githubusercontent.com/6634592/61904410-aae95500-aedb-11e9-8561-86466a575663.png)

The intention is to put this information in `@` annotations in the ts-defs