### PR TITLE
fix: ensure that sub keys can only be consumed by a single type (the first one)

### DIFF
--- a/src/DocsParser.ts
+++ b/src/DocsParser.ts
@@ -22,6 +22,7 @@ import {
   findContentInsideHeader,
   headingsAndContent,
   findConstructorHeader,
+  consumeTypedKeysList,
 } from './markdown-helpers';
 import { WEBSITE_BASE_DOCS_URL, REPO_BASE_DOCS_URL } from './constants';
 import { extendError } from './helpers';
@@ -245,12 +246,10 @@ export class DocsParser {
 
     expect(list).to.not.equal(null, `Structure file ${filePath} has no property list`);
 
-    const typedKeys = convertListToTypedKeys(list!);
-
     return {
       type: 'Structure',
       ...baseInfos[0].container,
-      properties: typedKeys.map(typedKey => ({
+      properties: consumeTypedKeysList(convertListToTypedKeys(list!)).map(typedKey => ({
         name: typedKey.key,
         description: typedKey.description,
         required: typedKey.required,

--- a/src/block-parsers.ts
+++ b/src/block-parsers.ts
@@ -12,6 +12,7 @@ import {
   extractReturnType,
   findContentAfterHeadingClose,
   StripReturnTypeBehavior,
+  consumeTypedKeysList,
 } from './markdown-helpers';
 import {
   MethodDocumentationBlock,
@@ -97,7 +98,7 @@ export const _headingToMethodBlock = (
       null,
       `Method ${heading.heading} has at least one parameter but no parameter type list`,
     );
-    parameters = convertListToTypedKeys(list).map(typedKey => ({
+    parameters = consumeTypedKeysList(convertListToTypedKeys(list)).map(typedKey => ({
       name: typedKey.key,
       description: typedKey.description,
       required: typedKey.required,
@@ -183,8 +184,7 @@ export const _headingToEventBlock = (heading: HeadingContent): EventDocumentatio
   ) {
     const list = findNextList(heading.content);
     if (list) {
-      const typedKeys = convertListToTypedKeys(list);
-      parameters = typedKeys.map(typedKey => ({
+      parameters = consumeTypedKeysList(convertListToTypedKeys(list)).map(typedKey => ({
         name: typedKey.key,
         description: typedKey.description,
         ...typedKey.type,


### PR DESCRIPTION
This ensures that types like Object | String don't both try to enumerate the sub keys.  Previously this resulted in a correctly typed object and a `String` with "possibleValues" equal to the keys of the object (which is straight up wrong).

At a high level now instead of passing around the raw TypedKey array we pass around a TypedKeyList struct which has a `consumed` property.  Calling `consumeTypedKeyList` on that struct will mark `consumed` as `true` and ensure no other call can consume that list.