### PR TITLE
fix: Remove unnecessary package.json `name` valid

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -41,16 +41,6 @@ if (!fs.pathExistsSync(packageJsonPath)) {
   process.exit(1);
 }
 
-const pj = require(packageJsonPath);
-if (pj.name !== 'electron') {
-  runner.fail(
-    chalk.red(
-      'The package.json file in the provided directory is not for Electron, please point this tool at a Electron repository',
-    ),
-  );
-  process.exit(1);
-}
-
 const resolvedOutDir =
   typeof outDir === 'string'
     ? path.isAbsolute(outDir)


### PR DESCRIPTION
Removes an unnecessary check to ensure the `name` property in the `package.json` file of a directory `docs-parser` is being run against is exactly equal to `electron`.

This change lowers the barrier for other projects to adopt docs-parser.