### PR TITLE
feat: extract all Electron specififc logic to plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ yarn global add electron-docs-parser
 cd ~/projects/path/to/electron/repo
 electron-docs-parser --dir ./
 
-# You now have ./electron-api.json with the entire Electron API
+# You now have ./api.json with the entire Electron API
 ```
 
 ## How it Works

--- a/src/DocsParserPlugin.ts
+++ b/src/DocsParserPlugin.ts
@@ -1,0 +1,26 @@
+import {
+  StructureDocumentationContainer,
+  BaseDocumentationContainer,
+  ClassDocumentationContainer,
+  ElementDocumentationContainer,
+  ModuleDocumentationContainer,
+} from './ParsedDocumentation';
+import Token = require('markdown-it/lib/token');
+
+export interface ExtendOptions {
+  relativeDocsPath: string;
+}
+
+export abstract class DocsParserPlugin<Options> {
+  constructor(protected readonly options: Options) {}
+
+  abstract extendContainer?(
+    container: BaseDocumentationContainer,
+    opts: ExtendOptions,
+  ): object | void;
+
+  abstract extendAPI?(
+    api: ClassDocumentationContainer | ElementDocumentationContainer | ModuleDocumentationContainer,
+    tokens: Token[],
+  ): object | void;
+}

--- a/src/ParsedDocumentation.ts
+++ b/src/ParsedDocumentation.ts
@@ -72,16 +72,9 @@ export declare type BaseDocumentationContainer = {
   description: string;
   version: string;
   slug: string;
-  websiteUrl: string;
-  repoUrl: string;
-};
-export declare type ProcessBlock = {
-  main: boolean;
-  renderer: boolean;
 };
 export declare type ModuleDocumentationContainer = {
   type: 'Module';
-  process: ProcessBlock;
   methods: MethodDocumentationBlock[];
   events: EventDocumentationBlock[];
   properties: PropertyDocumentationBlock[];
@@ -107,7 +100,6 @@ export declare type StructureDocumentationContainer = {
 } & BaseDocumentationContainer;
 export declare type ClassDocumentationContainer = {
   type: 'Class';
-  process: ProcessBlock;
   constructorMethod: Pick<MethodDocumentationBlock, 'signature' | 'parameters'> | null;
   instanceName: string;
   staticMethods: MethodDocumentationBlock[];
@@ -121,7 +113,6 @@ export declare type ClassDocumentationContainer = {
 } & BaseDocumentationContainer;
 export declare type ElementDocumentationContainer = {
   type: 'Element';
-  process: ProcessBlock;
   constructorMethod?: undefined;
   methods: MethodDocumentationBlock[];
   events: EventDocumentationBlock[];

--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -11,7 +11,6 @@ import {
   getTopLevelGenericType,
   findFirstHeading,
   consumeTypedKeysList,
-  findProcess,
 } from '../markdown-helpers';
 import { DocumentationTag } from '../ParsedDocumentation';
 
@@ -386,52 +385,6 @@ foo`),
       expect(() => consumeTypedKeysList(list)).toThrowErrorMatchingInlineSnapshot(
         `"Attempted to consume a typed keys list that has already been consumed"`,
       );
-    });
-  });
-
-  describe('findProcess()', () => {
-    it('should be available in main processe only', () => {
-      var proc = findProcess(getTokens('Process: [Main](../glossary.md#main-process)'));
-      expect(proc.main).toEqual(true);
-      expect(proc.renderer).toEqual(false);
-    });
-
-    it('should be available in renderer processe only', () => {
-      var proc = findProcess(getTokens('Process: [Renderer](../glossary.md#renderer-process)'));
-      expect(proc.main).toEqual(false);
-      expect(proc.renderer).toEqual(true);
-    });
-
-    it('should be available in both processes', () => {
-      var proc = findProcess(
-        getTokens(
-          'Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)',
-        ),
-      );
-      expect(proc.main).toEqual(true);
-      expect(proc.renderer).toEqual(true);
-    });
-
-    it('should be available in both processes', () => {
-      var proc = findProcess(
-        getTokens(
-          'Process: [Renderer](../glossary.md#renderer-process), [Main](../glossary.md#main-process)',
-        ),
-      );
-      expect(proc.main).toEqual(true);
-      expect(proc.renderer).toEqual(true);
-    });
-
-    it('should be available in both processes', () => {
-      var proc = findProcess(getTokens(''));
-      expect(proc.main).toEqual(true);
-      expect(proc.renderer).toEqual(true);
-    });
-
-    it('should be available in both processes', () => {
-      var proc = findProcess([]);
-      expect(proc.main).toEqual(true);
-      expect(proc.renderer).toEqual(true);
     });
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,0 @@
-export const WEBSITE_BASE_DOCS_URL = 'http://electronjs.org';
-export const REPO_BASE_DOCS_URL = (version: string) =>
-  `https://github.com/electron/electron/blob/${version}/docs/api`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { DocsParser } from './DocsParser';
+import { DocsParserPlugin } from './DocsParserPlugin';
 
 type ParseOptions = {
   baseDirectory: string;
   moduleVersion: string;
+  plugins?: DocsParserPlugin<any>[];
 };
 
 export async function parseDocs(options: ParseOptions) {
@@ -15,6 +17,7 @@ export async function parseDocs(options: ParseOptions) {
     options.moduleVersion,
     await getAllMarkdownFiles(electronDocsPath),
     await getAllMarkdownFiles(path.resolve(electronDocsPath, 'structures')),
+    options.plugins || [],
   );
 
   return await parser.parse();

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -6,7 +6,6 @@ import {
   MethodParameterDocumentation,
   PossibleStringValue,
   DocumentationTag,
-  ProcessBlock,
 } from './ParsedDocumentation';
 
 const tagMap = {
@@ -716,20 +715,4 @@ export const convertListToTypedKeys = (listTokens: Token[]): TypedKeyList => {
   const list = getNestedList(listTokens);
 
   return unconsumedTypedKeyList(convertNestedListToTypedKeys(list));
-};
-
-export const findProcess = (tokens: Token[]): ProcessBlock => {
-  for (const tk of tokens) {
-    if (tk.type === 'inline' && tk.content.indexOf('Process') === 0) {
-      const ptks = tk.children.slice(2, tk.children.length - 1);
-      const procs: ProcessBlock = { main: false, renderer: false };
-      for (const ptk of ptks) {
-        if (ptk.type !== 'text') continue;
-        if (ptk.content === 'Main') procs.main = true;
-        if (ptk.content === 'Renderer') procs.renderer = true;
-      }
-      return procs;
-    }
-  }
-  return { main: true, renderer: true };
 };

--- a/src/plugins/__tests__/electron-process.spec.ts
+++ b/src/plugins/__tests__/electron-process.spec.ts
@@ -1,0 +1,54 @@
+import MarkdownIt from 'markdown-it';
+
+import { findProcess } from '../electron-process';
+
+const getTokens = (md: string) => {
+  const markdown = new MarkdownIt();
+  return markdown.parse(md, {});
+};
+
+describe('findProcess()', () => {
+  it('should be available in main processe only', () => {
+    var proc = findProcess(getTokens('Process: [Main](../glossary.md#main-process)'));
+    expect(proc.main).toEqual(true);
+    expect(proc.renderer).toEqual(false);
+  });
+
+  it('should be available in renderer processe only', () => {
+    var proc = findProcess(getTokens('Process: [Renderer](../glossary.md#renderer-process)'));
+    expect(proc.main).toEqual(false);
+    expect(proc.renderer).toEqual(true);
+  });
+
+  it('should be available in both processes', () => {
+    var proc = findProcess(
+      getTokens(
+        'Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)',
+      ),
+    );
+    expect(proc.main).toEqual(true);
+    expect(proc.renderer).toEqual(true);
+  });
+
+  it('should be available in both processes', () => {
+    var proc = findProcess(
+      getTokens(
+        'Process: [Renderer](../glossary.md#renderer-process), [Main](../glossary.md#main-process)',
+      ),
+    );
+    expect(proc.main).toEqual(true);
+    expect(proc.renderer).toEqual(true);
+  });
+
+  it('should be available in both processes', () => {
+    var proc = findProcess(getTokens(''));
+    expect(proc.main).toEqual(true);
+    expect(proc.renderer).toEqual(true);
+  });
+
+  it('should be available in both processes', () => {
+    var proc = findProcess([]);
+    expect(proc.main).toEqual(true);
+    expect(proc.renderer).toEqual(true);
+  });
+});

--- a/src/plugins/electron-process.ts
+++ b/src/plugins/electron-process.ts
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+
+import { DocsParserPlugin, ExtendOptions } from '../DocsParserPlugin';
+import {
+  ClassDocumentationContainer,
+  ElementDocumentationContainer,
+  ModuleDocumentationContainer,
+} from '../ParsedDocumentation';
+import Token = require('markdown-it/lib/token');
+
+/**
+ * This plugin adds a "process" object to all parsed API files that indicate which process
+ * the API is available in in Electron.
+ */
+
+export interface ElectronProcessPluginOptions {}
+
+export interface ElectronProcessPluginAPIExtension {
+  process: {
+    main: boolean;
+    renderer: boolean;
+  };
+}
+
+export const findProcess = (tokens: Token[]): ElectronProcessPluginAPIExtension['process'] => {
+  for (const tk of tokens) {
+    if (tk.type === 'inline' && tk.content.indexOf('Process') === 0) {
+      const ptks = tk.children.slice(2, tk.children.length - 1);
+      const procs = { main: false, renderer: false };
+      for (const ptk of ptks) {
+        if (ptk.type !== 'text') continue;
+        if (ptk.content === 'Main') procs.main = true;
+        if (ptk.content === 'Renderer') procs.renderer = true;
+      }
+      return procs;
+    }
+  }
+  return { main: true, renderer: true };
+};
+
+export default class ElectronProcessPlugin extends DocsParserPlugin<ElectronProcessPluginOptions> {
+  extendContainer: undefined;
+
+  extendAPI(
+    api: ClassDocumentationContainer | ElementDocumentationContainer | ModuleDocumentationContainer,
+    tokens: Token[],
+  ): ElectronProcessPluginAPIExtension {
+    return {
+      process: findProcess(tokens),
+    };
+  }
+}

--- a/src/plugins/url-provider.ts
+++ b/src/plugins/url-provider.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai';
+
+import { DocsParserPlugin, ExtendOptions } from '../DocsParserPlugin';
+import { BaseDocumentationContainer } from '../ParsedDocumentation';
+
+/**
+ * This plugin adds "repoUrl" and "websiteURL" to each documention block so that users
+ * can view the documentation that generated the block in either it's source form or on
+ * your website
+ */
+
+export interface URLProviderOptions {
+  // E.g.
+  websiteDocsBaseURL: string;
+  websiteDocsURLIncludesVersion?: boolean;
+  // E.g. https://github.com/electron/electron/blob
+  repoDocsBaseURL: string;
+}
+
+export interface URLProviderContainerExtension {
+  websiteUrl: string;
+  repoUrl: string;
+}
+
+export default class URLProviderPlugin extends DocsParserPlugin<URLProviderOptions> {
+  private getURLInfo = (
+    version: string,
+    relativeDocsPath: string,
+  ): URLProviderContainerExtension => {
+    expect(
+      this.options,
+      'should provide all required config to URLProviderPlugin',
+    ).to.have.property('websiteDocsBaseURL');
+    expect(
+      this.options,
+      'should provide all required config to URLProviderPlugin',
+    ).to.have.property('repoDocsBaseURL');
+    return {
+      websiteUrl: `${this.options.websiteDocsBaseURL}/${
+        this.options.websiteDocsURLIncludesVersion ? `${version}/` : ''
+      }${relativeDocsPath}`,
+      repoUrl: `${this.options.repoDocsBaseURL}/v${version}/${relativeDocsPath}.md`,
+    };
+  };
+
+  extendContainer(container: BaseDocumentationContainer, { relativeDocsPath }: ExtendOptions) {
+    return this.getURLInfo(container.version, relativeDocsPath);
+  }
+
+  extendAPI: undefined;
+}


### PR DESCRIPTION
* Website URL
* Repo URL
* Filename (now api.json)
* Process information

BREAKING CHANGE

To replicate the old Electron file you now use

```sh
electron-docs-parser \
  --dir ../electron/src/electron \
  --plugin url-provider \
    --url-provider.websiteDocsBaseURL="https://electronjs.org" \
    --url-provider.repoDocsBaseURL="https://github.com/electron/electron/blob" \
  --plugin electron-process
```

TODO:
* [ ] Make the plugins configurable via a `.docsparser.json` file or similar