### PR TITLE
fix: improve provided context in key token error

### DIFF
--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -669,7 +669,7 @@ const convertNestedListToTypedKeys = (list: List): TypedKey[] => {
       'Expected token token to have at least 1 child for typed key extraction',
     );
     const keyToken = targetToken.children[0];
-    expect(keyToken.type).to.equal('code_inline', 'Expected key token to be an inline code block');
+    expect(keyToken.type).to.equal('code_inline', `Expected key token to be an inline code block but instead encountered "${keyToken.content}"`);
     const typeAndDescriptionTokens = targetToken.children.slice(1);
     const joinedContent = safelyJoinTokens(typeAndDescriptionTokens);
 

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -669,7 +669,10 @@ const convertNestedListToTypedKeys = (list: List): TypedKey[] => {
       'Expected token token to have at least 1 child for typed key extraction',
     );
     const keyToken = targetToken.children[0];
-    expect(keyToken.type).to.equal('code_inline', `Expected key token to be an inline code block but instead encountered "${keyToken.content}"`);
+    expect(keyToken.type).to.equal(
+      'code_inline',
+      `Expected key token to be an inline code block but instead encountered "${keyToken.content}"`,
+    );
     const typeAndDescriptionTokens = targetToken.children.slice(1);
     const joinedContent = safelyJoinTokens(typeAndDescriptionTokens);
 


### PR DESCRIPTION
Improves the context provided when hitting the error that can be found [here](https://github.com/electron/docs-parser/blob/master/src/markdown-helpers.ts#L672).

Here's an example of the output before this PR:
```
✖ Generating API in directory: "/Users/cyren/GitHub/node-docs-parser"
An error occurred while processing: "/Users/cyren/GitHub/node-docs-parser/docs/api/v8.md"
AssertionError: Expected key token to be an inline code block: expected 'text' to equal 'code_inline'
```

And here's an example after:
```
$ electron-docs-parser --dir ./
✖ Generating API in directory: "/Users/cyren/GitHub/node-docs-parser"
An error occurred while processing: "/Users/cyren/GitHub/node-docs-parser/docs/api/v8.md"
AssertionError: Expected key token to be an inline code block at "Returns: {string} The filename where the snapshot was saved.": expected 'text' to equal 'code_inline'
```