### PR TITLE
feat: add a multi-package mode so that classes are exported under a module instead of at the top level of the API

### DIFF
--- a/src/ParsedDocumentation.ts
+++ b/src/ParsedDocumentation.ts
@@ -91,6 +91,7 @@ export declare type ModuleDocumentationContainer = {
   instanceProperties?: undefined;
   staticProperties?: undefined;
   staticMethods?: undefined;
+  exportedClasses: ClassDocumentationContainer[];
 } & BaseDocumentationContainer;
 export declare type StructureDocumentationContainer = {
   type: 'Structure';

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -9,9 +9,17 @@ import pretty from 'pretty-ms';
 import { parseDocs } from '.';
 import chalk from 'chalk';
 
-const args = minimist(process.argv);
+const args = minimist(process.argv, {
+  default: {
+    packageMode: 'single',
+  },
+});
 
-const { dir, outDir, help } = args;
+const { dir, outDir, packageMode, help } = args;
+if (!['single', 'multi'].includes(packageMode)) {
+  console.error(chalk.red('packageMode must be one of "single" and "multi"'));
+  process.exit(1);
+}
 
 if (help) {
   console.info(
@@ -58,6 +66,7 @@ fs.mkdirp(resolvedOutDir).then(() =>
   parseDocs({
     baseDirectory: resolvedDir,
     moduleVersion: pj.version,
+    packageMode,
   })
     .then(data =>
       fs.writeJson(path.resolve(resolvedOutDir, './electron-api.json'), data, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,11 @@ import { DocsParser } from './DocsParser';
 type ParseOptions = {
   baseDirectory: string;
   moduleVersion: string;
+  packageMode?: 'single' | 'multi';
 };
 
 export async function parseDocs(options: ParseOptions) {
+  const packageMode = options.packageMode || 'single';
   const electronDocsPath = path.resolve(options.baseDirectory, 'docs', 'api');
 
   const parser = new DocsParser(
@@ -15,6 +17,7 @@ export async function parseDocs(options: ParseOptions) {
     options.moduleVersion,
     await getAllMarkdownFiles(electronDocsPath),
     await getAllMarkdownFiles(path.resolve(electronDocsPath, 'structures')),
+    packageMode,
   );
 
   return await parser.parse();


### PR DESCRIPTION
This is mostly for projects like `node` that export multiple packages from their API instead of multiple modules from a single package.