### PR TITLE
fix: return type incorrectly checking periods

### DIFF
--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -442,7 +442,7 @@ export const extractReturnType = (
   }
 
   const returnsWithNewLineMatch = description.match(
-    new RegExp(`${prefix} \`([^\`]+?)\`:?(\. |\n|$)`),
+    new RegExp(`${prefix} \`([^\`]+?)\`:?(\. |\.\n|\n|$)`),
   );
   const returnsWithHyphenMatch = description.match(new RegExp(`${prefix} \`([^\`]+?)\` - `));
   const returnsWithContinousSentence = description.match(new RegExp(`${prefix} \`([^\`]+?)\` `));


### PR DESCRIPTION
Prompted by https://github.com/electron/electron/issues/21231.

The old Regex:
<img width="306" alt="Screen Shot 2019-12-05 at 3 24 02 PM" src="https://user-images.githubusercontent.com/2036040/70282640-47b5dc00-1773-11ea-947e-a74f846fc0b5.png">

Matches:
<img width="244" alt="Screen Shot 2019-12-05 at 3 24 39 PM" src="https://user-images.githubusercontent.com/2036040/70282672-63b97d80-1773-11ea-9e22-ed579b2df220.png">
but doesn't match:
<img width="249" alt="Screen Shot 2019-12-05 at 3 24 45 PM" src="https://user-images.githubusercontent.com/2036040/70282683-69af5e80-1773-11ea-913b-240b921fc5fd.png">

owing to a typo where it expected space after the `.` in order to match:
<img width="282" alt="Screen Shot 2019-12-05 at 3 25 33 PM" src="https://user-images.githubusercontent.com/2036040/70282703-7df35b80-1773-11ea-81a9-c4a3bfe74432.png">

This fixes that by changing the regex to remove the extra space requirement after the period.

cc @MarshallOfSound 