### PR TITLE
feat: allow useReadme flag for parsing only the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ electron-docs-parser --dir ./
 # You now have ./electron-api.json with the entire Electron API
 ```
 
+Options:
+* `--useReadme` - Assume all documentation is in the module's base `README.md` file 
+* `--dir` - The base directory where documentation is located.
+  * API documentation must be located in `/docs/api` within the specified base directory.
+  * API structures documentation must be located in `/docs/api/structures` within the specified base directory.
+* `--packageMode` - Can be `single` or `multi`; default `single`. Specifying `multi` allows exporting multiple packages from an API instead of multiple modules from a single package.
+
 ## How it Works
 
 We generate a markdown AST for every documentation file and search for

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -15,7 +15,7 @@ const args = minimist(process.argv, {
   },
 });
 
-const { dir, outDir, packageMode, help } = args;
+const { dir, outDir, useReadme, packageMode, help } = args;
 if (!['single', 'multi'].includes(packageMode)) {
   console.error(chalk.red('packageMode must be one of "single" and "multi"'));
   process.exit(1);
@@ -64,6 +64,7 @@ const start = Date.now();
 
 fs.mkdirp(resolvedOutDir).then(() =>
   parseDocs({
+    useReadme: useReadme ? true : false,
     baseDirectory: resolvedDir,
     moduleVersion: pj.version,
     packageMode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,19 +4,36 @@ import { DocsParser } from './DocsParser';
 
 type ParseOptions = {
   baseDirectory: string;
+  useReadme: boolean;
   moduleVersion: string;
   packageMode?: 'single' | 'multi';
 };
 
 export async function parseDocs(options: ParseOptions) {
   const packageMode = options.packageMode || 'single';
-  const electronDocsPath = path.resolve(options.baseDirectory, 'docs', 'api');
+
+  const apiDocsPath = options.baseDirectory || path.resolve('./', 'docs', 'api');
+  const structuresPath = path.resolve(apiDocsPath, 'structures');
+
+  let structures: string[] = [];
+  let apis: string[] = [];
+
+  if (options.useReadme) {
+    const readmePath = path.resolve(options.baseDirectory, 'README.md');
+    if (!fs.existsSync(readmePath)) {
+      throw new Error('README.md file not found');
+    }
+    apis = [readmePath];
+  } else {
+    structures = await getAllMarkdownFiles(structuresPath);
+    apis = await getAllMarkdownFiles(apiDocsPath);
+  }
 
   const parser = new DocsParser(
     options.baseDirectory,
     options.moduleVersion,
-    await getAllMarkdownFiles(electronDocsPath),
-    await getAllMarkdownFiles(path.resolve(electronDocsPath, 'structures')),
+    apis,
+    structures,
     packageMode,
   );
 


### PR DESCRIPTION
Allow parsing for smaller modules like https://github.com/codebytere/node-mac-userdefaults, whose docs are all located in the main README file.

Example usage: 

```sh
electron-docs-parser --dir=./ --useReadme
```

cc @MarshallOfSound 