### PR TITLE
chore: re-enable accidentally disabled tests

### DIFF
--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -161,7 +161,7 @@ def fn():
         expect(values[2].value).toBe('c');
       });
 
-      it.only('should extract an enum with underscores in the values', () => {
+      it('should extract an enum with underscores in the values', () => {
         const values = extractStringEnum('Values includes `a`, `b_c` and `d`')!;
         expect(values).not.toBe(null);
         expect(values).toHaveLength(3);


### PR DESCRIPTION
Looks like an `it.only` snuck into a commit and was causing most of the tests to be skipped.