### PR TITLE
feat: urlFragment for methods/properties/events

### DIFF
--- a/src/ParsedDocumentation.ts
+++ b/src/ParsedDocumentation.ts
@@ -54,6 +54,7 @@ export declare type DocumentationBlock = {
   name: string;
   description: string;
   additionalTags: DocumentationTag[];
+  urlFragment?: string;
 };
 export declare type MethodDocumentationBlock = DocumentationBlock & {
   signature: string;

--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -13,6 +13,7 @@ import {
   findFirstHeading,
   consumeTypedKeysList,
   findProcess,
+  slugifyHeading,
 } from '../markdown-helpers';
 import { DocumentationTag } from '../ParsedDocumentation';
 
@@ -537,6 +538,15 @@ foo`),
       var proc = findProcess([]);
       expect(proc.main).toEqual(true);
       expect(proc.renderer).toEqual(true);
+    });
+  });
+
+  describe('slugifyHeading', () => {
+    it('should correctly slugify a complex heading', () => {
+      const heading =
+        '`systemPreferences.isHighContrastColorScheme()` _macOS_ _Windows_ _Deprecated_';
+      const slugified = 'systempreferencesishighcontrastcolorscheme-macos-windows-deprecated';
+      expect(slugifyHeading(heading)).toBe(slugified);
     });
   });
 });

--- a/src/block-parsers.ts
+++ b/src/block-parsers.ts
@@ -13,6 +13,7 @@ import {
   findContentAfterHeadingClose,
   StripReturnTypeBehavior,
   consumeTypedKeysList,
+  slugifyHeading,
 } from './markdown-helpers';
 import {
   MethodDocumentationBlock,
@@ -130,6 +131,7 @@ export const _headingToMethodBlock = (
     parameters,
     returns: parsedReturnType,
     additionalTags: parseHeadingTags(headingTags),
+    urlFragment: `#${slugifyHeading(heading.heading)}`,
   };
 };
 
@@ -159,6 +161,7 @@ export const _headingToPropertyBlock = (heading: HeadingContent): PropertyDocume
     description: parsedDescription,
     required: !/\(optional\)/i.test(parsedDescription),
     additionalTags: parseHeadingTags(headingTags),
+    urlFragment: `#${slugifyHeading(heading.heading)}`,
     ...parsedReturnType!,
   };
 };
@@ -196,6 +199,7 @@ export const _headingToEventBlock = (heading: HeadingContent): EventDocumentatio
     description,
     parameters,
     additionalTags: parseHeadingTags(headingTags),
+    urlFragment: `#${slugifyHeading(heading.heading)}`,
   };
 };
 

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -766,3 +766,10 @@ export const findProcess = (tokens: Token[]): ProcessBlock => {
   }
   return { main: true, renderer: true };
 };
+
+export const slugifyHeading = (heading: string): string => {
+  return heading
+    .replace(/[^A-Za-z0-9 \-]/g, '')
+    .replace(/ /g, '-')
+    .toLowerCase();
+};


### PR DESCRIPTION
This is intended as a solution to the issue mentioned described in electron/algolia-indices#227. The code in that repo can't accurately create URLs from `electron-api.json` because some of the necessary information isn't included. By adding a new field that loop can be closed, and the search indexes should be robust against changes in docs conventions. I decided on `urlFragment` rather than setting the full `websiteUrl` to avoid duplication, and because the URL fragment should be applicable to both the `websiteUrl` and `repoUrl`.