### PR TITLE
fix: correct GitHub repo base URL

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
 export const WEBSITE_BASE_DOCS_URL = 'https://electronjs.org';
 export const REPO_BASE_DOCS_URL = (version: string) =>
-  `https://github.com/electron/electron/blob/${version}/docs/api`;
+  `https://github.com/electron/electron/blob/${version}`;


### PR DESCRIPTION
Current version is generating incorrect URLs by duplicating `docs/api/`.