### PR TITLE
fix: respect {} in safe typestring splitting

### DIFF
--- a/src/__tests__/__snapshots__/markdown-helpers.spec.ts.snap
+++ b/src/__tests__/__snapshots__/markdown-helpers.spec.ts.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`markdown-helpers rawTypeToTypeInformation() should allow commas in object types 1`] = `
+Object {
+  "collection": false,
+  "parameters": Array [],
+  "returns": Object {
+    "collection": false,
+    "type": "{a: string, b: string}",
+  },
+  "type": "Function",
+}
+`;
+
 exports[`markdown-helpers rawTypeToTypeInformation() should map a Promise types correctly 1`] = `
 Object {
   "collection": false,

--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -290,8 +290,10 @@ def fn():
     });
 
     it('should allow commas in object types', () => {
-      expect(rawTypeToTypeInformation('Function<{a: string, b: string}>', '', null)).toMatchSnapshot();
-    })
+      expect(
+        rawTypeToTypeInformation('Function<{a: string, b: string}>', '', null),
+      ).toMatchSnapshot();
+    });
   });
 
   describe('findNextList()', () => {

--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -288,6 +288,10 @@ def fn():
         ),
       ).toMatchSnapshot();
     });
+
+    it('should allow commas in object types', () => {
+      expect(rawTypeToTypeInformation('Function<{a: string, b: string}>', '', null)).toMatchSnapshot();
+    })
   });
 
   describe('findNextList()', () => {

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -194,9 +194,11 @@ export const safelySeparateTypeStringOn = (typeString: string, targetChar: strin
       current += char;
       switch (char) {
         case '<':
+        case '{':
           depth++;
           break;
         case '>':
+        case '}':
           depth--;
           break;
       }


### PR DESCRIPTION
This allows constructions such as:

```md
### `foo(bar)`

* `bar` Function<{type: 'a'} | { type: 'b', extraThing? 'c' }>
```