### PR TITLE
fix: include 'v' prefix on version in GitHub URL

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
 export const WEBSITE_BASE_DOCS_URL = 'https://electronjs.org';
 export const REPO_BASE_DOCS_URL = (version: string) =>
-  `https://github.com/electron/electron/blob/${version}`;
+  `https://github.com/electron/electron/blob/v${version}`;


### PR DESCRIPTION
Tags on the `electron/electron` repository begin with 'v'.