### PR TITLE
chore: use matching version of @types/markdown-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
-    "@types/markdown-it": "^0.0.9",
+    "@types/markdown-it": "^10.0.0",
     "chai": "^4.2.0",
     "chalk": "^3.0.0",
     "fs-extra": "^8.1.0",

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -696,16 +696,16 @@ const convertNestedListToTypedKeys = (list: List): TypedKey[] => {
     // We take the middle token as it is the thing enclosed in the paragraph
     const targetToken = item.tokens[1];
     // Need at least a key and a type
-    expect(targetToken.children.length).to.be.at.least(
+    expect(targetToken.children!.length).to.be.at.least(
       1,
       'Expected token token to have at least 1 child for typed key extraction',
     );
-    const keyToken = targetToken.children[0];
+    const keyToken = targetToken.children![0];
     expect(keyToken.type).to.equal(
       'code_inline',
       `Expected key token to be an inline code block but instead encountered "${keyToken.content}"`,
     );
-    const typeAndDescriptionTokens = targetToken.children.slice(1);
+    const typeAndDescriptionTokens = targetToken.children!.slice(1);
     const joinedContent = safelyJoinTokens(typeAndDescriptionTokens);
 
     let rawType = 'String';
@@ -756,7 +756,7 @@ export const convertListToTypedKeys = (listTokens: Token[]): TypedKeyList => {
 export const findProcess = (tokens: Token[]): ProcessBlock => {
   for (const tk of tokens) {
     if (tk.type === 'inline' && tk.content.indexOf('Process') === 0) {
-      const ptks = tk.children.slice(2, tk.children.length - 1);
+      const ptks = tk.children!.slice(2, tk.children!.length - 1);
       const procs: ProcessBlock = { main: false, renderer: false };
       for (const ptk of ptks) {
         if (ptk.type !== 'text') continue;

--- a/yarn.lock
+++ b/yarn.lock
@@ -572,12 +572,18 @@
   version "4.14.119"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.119.tgz#be847e5f4bc3e35e46d041c394ead8b603ad8b39"
 
-"@types/markdown-it@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-0.0.9.tgz#a5d552f95216c478e0a27a5acc1b28dcffd989ce"
-  integrity sha512-IFSepyZXbF4dgSvsk8EsgaQ/8Msv1I5eTL0BZ0X3iGO9jw6tCVtPG8HchIPm3wrkmGdqZOD42kE0zplVi1gYDA==
+"@types/markdown-it@^10.0.0":
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/@types/markdown-it/-/markdown-it-10.0.2.tgz#f93334b9c7821ddb19865dfd91ecf688094c2626"
+  integrity sha512-FGKiVW1UgeIEAChYAuHcfCd0W4LsMEyrSyTVaZiuJhwR4BwSVUD8JKnzmWAMK2FHNLZSPGUaEkpa/dkZj2uq1w==
   dependencies:
     "@types/linkify-it" "*"
+    "@types/mdurl" "*"
+
+"@types/mdurl@*":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/mdurl/-/mdurl-1.0.2.tgz#e2ce9d83a613bacf284c7be7d491945e39e1f8e9"
+  integrity sha512-eC4U9MlIcu2q0KQmXszyn5Akca/0jrQmwDRgpAMJai7qBWq4amIQhZyNau4VYGtCeALvW1/NtjzJJ567aZxfKA==
 
 "@types/minimatch@*":
   version "3.0.3"


### PR DESCRIPTION
The version of `@types/markdown-it` wasn't consistent with `markdown-it`, which didn't seem correct. This rectifies that. Require a slight code change when the correct types were used.