### PR TITLE
feat: add new Event support for extensible params

### DIFF
--- a/src/ParsedDocumentation.ts
+++ b/src/ParsedDocumentation.ts
@@ -19,6 +19,14 @@ export declare type DetailedObjectType = {
   type: 'Object';
   properties: PropertyDocumentationBlock[];
 };
+export declare type DetailedEventType = {
+  type: 'Event';
+  eventProperties: PropertyDocumentationBlock[];
+};
+export declare type DetailedEventReferenceType = {
+  type: 'Event';
+  eventPropertiesReference: TypeInformation;
+};
 export declare type DetailedFunctionType = {
   type: 'Function';
   parameters: MethodParameterDocumentation[];
@@ -30,6 +38,8 @@ export declare type DetailedType = (
     }
   | DetailedFunctionType
   | DetailedObjectType
+  | DetailedEventType
+  | DetailedEventReferenceType
   | DetailedStringType
   | {
       type: string;

--- a/src/block-parsers.ts
+++ b/src/block-parsers.ts
@@ -201,6 +201,7 @@ export const _headingToEventBlock = (heading: HeadingContent): EventDocumentatio
         name: typedKey.key,
         description: typedKey.description,
         ...typedKey.type,
+        additionalTags: typedKey.additionalTags,
         required: true,
       }));
     }

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -361,7 +361,7 @@ export const rawTypeToTypeInformation = (
         return info;
       });
 
-    // Special case, when the generic type is "Event" then their should be no declared
+    // Special case, when the generic type is "Event" then there should be no declared
     // innerTypes.  Instead we extract the following list as event parameters.
     if (genericTypeString === 'Event') {
       if (innerTypes.length) {


### PR DESCRIPTION
This adds support for these two new forms of syntax for declaring event objects:

#### Inline Params

```markdown
#### Event: 'will-navigate'

Returns:

* `event` Event<>
  * `url` string - The URL the frame is navigating to.
  * `isSameDocument` boolean - Whether the navigation happened without changing
    document. Examples of same document navigations are reference fragment
    navigations, pushState/replaceState, and same page history navigation.
  * `isMainFrame` boolean - True if the navigation is taking place in a main frame.
  * `frame` WebFrameMain - The frame to be navigated.
  * `initiator` WebFrameMain (optional) - The frame which initiated the
    navigation, which can be a parent frame (e.g. via `window.open` with a
    frame's name), or null if the navigation was not initiated by a frame. This
    can also be null if the initiating frame was deleted before the event was
    emitted.
* `url` string _Deprecated_
* `isInPlace` boolean _Deprecated_
* `isMainFrame` boolean _Deprecated_
* `frameProcessId` Integer _Deprecated_
* `frameRoutingId` Integer _Deprecated_
```

##### Structure Referenced Params

```markdown
#### Event: 'did-redirect-navigation'

Returns:

* `event` Event<[NavigationEventParams](structures/navigation-event-params.md)>
* `url` string _Deprecated_
* `isInPlace` boolean _Deprecated_
* `isMainFrame` boolean _Deprecated_
* `frameProcessId` Integer _Deprecated_
* `frameRoutingId` Integer _Deprecated_
```

This is pair with a ts-defs PR and https://github.com/electron/electron/pull/37085 will be the first consumer.