### PR TITLE
feat: add utility process

### DIFF
--- a/src/ParsedDocumentation.ts
+++ b/src/ParsedDocumentation.ts
@@ -90,6 +90,7 @@ export declare type BaseDocumentationContainer = {
 export declare type ProcessBlock = {
   main: boolean;
   renderer: boolean;
+  utility: boolean;
   exported: boolean;
 };
 export declare type ModuleDocumentationContainer = {

--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -530,19 +530,28 @@ foo`),
   });
 
   describe('findProcess()', () => {
-    it('should be available in main processe only', () => {
+    it('should be available in main process only', () => {
       var proc = findProcess(getTokens('Process: [Main](../glossary.md#main-process)'));
       expect(proc.main).toEqual(true);
       expect(proc.renderer).toEqual(false);
+      expect(proc.utility).toEqual(false);
     });
 
-    it('should be available in renderer processe only', () => {
+    it('should be available in renderer process only', () => {
       var proc = findProcess(getTokens('Process: [Renderer](../glossary.md#renderer-process)'));
       expect(proc.main).toEqual(false);
       expect(proc.renderer).toEqual(true);
+      expect(proc.utility).toEqual(false);
     });
 
-    it('should be available in both processes', () => {
+    it('should be available in utility process only', () => {
+      var proc = findProcess(getTokens('Process: [Utility](../glossary.md#utility-process)'));
+      expect(proc.main).toEqual(false);
+      expect(proc.renderer).toEqual(false);
+      expect(proc.utility).toEqual(true);
+    });
+
+    it('should be available in main and renderer processes', () => {
       var proc = findProcess(
         getTokens(
           'Process: [Main](../glossary.md#main-process), [Renderer](../glossary.md#renderer-process)',
@@ -550,9 +559,10 @@ foo`),
       );
       expect(proc.main).toEqual(true);
       expect(proc.renderer).toEqual(true);
+      expect(proc.utility).toEqual(false);
     });
 
-    it('should be available in both processes', () => {
+    it('should be available in main and renderer processes', () => {
       var proc = findProcess(
         getTokens(
           'Process: [Renderer](../glossary.md#renderer-process), [Main](../glossary.md#main-process)',
@@ -560,18 +570,32 @@ foo`),
       );
       expect(proc.main).toEqual(true);
       expect(proc.renderer).toEqual(true);
+      expect(proc.utility).toEqual(false);
     });
 
-    it('should be available in both processes', () => {
+    it('should be available in main and utility processes', () => {
+      var proc = findProcess(
+        getTokens(
+          'Process: [Main](../glossary.md#main-process), [Utility](../glossary.md#renderer-process)',
+        ),
+      );
+      expect(proc.main).toEqual(true);
+      expect(proc.renderer).toEqual(false);
+      expect(proc.utility).toEqual(true);
+    });
+
+    it('should be available in all processes', () => {
       var proc = findProcess(getTokens(''));
       expect(proc.main).toEqual(true);
       expect(proc.renderer).toEqual(true);
+      expect(proc.utility).toEqual(true);
     });
 
-    it('should be available in both processes', () => {
+    it('should be available in all processes', () => {
       var proc = findProcess([]);
       expect(proc.main).toEqual(true);
       expect(proc.renderer).toEqual(true);
+      expect(proc.utility).toEqual(true);
     });
   });
 

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -818,6 +818,7 @@ export const findProcess = (tokens: Token[]): ProcessBlock => {
       const procs: ProcessBlock = {
         main: false,
         renderer: false,
+        utility: false,
         exported: !ptks.some(
           ptk => ptk.type === 'text' && ptk.content.startsWith('This class is not exported'),
         ),
@@ -826,11 +827,12 @@ export const findProcess = (tokens: Token[]): ProcessBlock => {
         if (ptk.type !== 'text') continue;
         if (ptk.content === 'Main') procs.main = true;
         if (ptk.content === 'Renderer') procs.renderer = true;
+        if (ptk.content === 'Utility') procs.utility = true;
       }
       return procs;
     }
   }
-  return { main: true, renderer: true, exported: false };
+  return { main: true, renderer: true, utility: true, exported: false };
 };
 
 export const slugifyHeading = (heading: string): string => {


### PR DESCRIPTION
This adds support for reading the utility process from `Process:` blocks.

This is needed to add new API to the utility process. Currently, the only API in the utility process is not exported, [doc](https://github.com/electron/electron/blob/713d8c4167a07971775db847adca880f49e8d381/docs/api/parent-port.md?plain=1#L5).

See https://github.com/electron/electron/pull/40017 for an example of adding new API to the utility process that will need this change.