### PR TITLE
fix: parse property types containing hyphens

### DIFF
--- a/src/__tests__/markdown-helpers.spec.ts
+++ b/src/__tests__/markdown-helpers.spec.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import MarkdownIt from 'markdown-it';
 
 import {
+  convertListToTypedKeys,
   safelyJoinTokens,
   extractStringEnum,
   extractReturnType,
@@ -666,6 +667,24 @@ foo`),
       expect(() => consumeTypedKeysList(list)).toThrowErrorMatchingInlineSnapshot(
         `"Attempted to consume a typed keys list that has already been consumed"`,
       );
+    });
+
+    it('should correctly parse types containing hyphens', () => {
+      const list = findNextList(getTokens("* `prop` 'string-enum' - description"));
+      const typedKeys = convertListToTypedKeys(list!);
+      const consumed = consumeTypedKeysList(typedKeys);
+      expect(consumed).toStrictEqual([
+        {
+          type: {
+            collection: false,
+            type: "'string-enum'",
+          },
+          key: 'prop',
+          description: 'description',
+          required: true,
+          additionalTags: [],
+        },
+      ]);
     });
   });
 

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -932,7 +932,8 @@ const convertNestedListToTypedKeys = (list: List): TypedKey[] => {
 
     let rawType = 'String';
     if (typeAndDescriptionTokens.length !== 0) {
-      rawType = joinedContent.split('-')[0];
+      // Type can contain hyphen (e.g. 'string-enum') so require surrounding spaces.
+      rawType = joinedContent.split(' - ')[0];
     }
 
     const rawDescription = joinedContent.substr(rawType.length);


### PR DESCRIPTION
I was testing out adding a struct property which is a string literal. When the string literal contains a hyphen, it breaks parsing.

```
* `prop` 'string-enum' - description
```
would split the type into `'string` with a description of `enum' - description`