### PR TITLE
feat: enforce lowercase primitive type names

### DIFF
--- a/src/ParsedDocumentation.ts
+++ b/src/ParsedDocumentation.ts
@@ -12,7 +12,7 @@ export declare type PossibleStringValue = {
   description: string;
 };
 export declare type DetailedStringType = {
-  type: 'String';
+  type: 'string';
   possibleValues: PossibleStringValue[] | null;
 };
 export declare type DetailedObjectType = {

--- a/src/markdown-helpers.ts
+++ b/src/markdown-helpers.ts
@@ -320,10 +320,14 @@ export const rawTypeToTypeInformation = (
             }))
           : [],
     };
-  } else if (typeString === 'String' || typeString === 'string') {
+  } else if (typeString === 'Boolean' || typeString === 'Number' || typeString === 'String') {
+    throw new Error(
+      `Use lowercase "${typeString.toLowerCase()}" instead of "${typeString}" for a primitive type`,
+    );
+  } else if (typeString === 'string') {
     return {
       collection,
-      type: 'String',
+      type: 'string',
       possibleValues:
         subTypedKeys && !subTypedKeys.consumed
           ? consumeTypedKeysList(subTypedKeys).map<PossibleStringValue>((typedKey) => ({
@@ -895,7 +899,7 @@ const convertNestedListToTypedKeys = (list: List): TypedKey[] => {
   for (const item of list.items) {
     // If the current list would fail checks, but it has a nested list, assume that the nested list is the content we want
     // E.g.
-    // * `foo` - String
+    // * `foo` - string
     //   * On windows these keys
     //      * `option1`
     //      * `option2`
@@ -930,7 +934,7 @@ const convertNestedListToTypedKeys = (list: List): TypedKey[] => {
     const typeAndDescriptionTokens = targetToken.children!.slice(1);
     const joinedContent = safelyJoinTokens(typeAndDescriptionTokens);
 
-    let rawType = 'String';
+    let rawType = 'string';
     if (typeAndDescriptionTokens.length !== 0) {
       rawType = joinedContent.split('-')[0];
     }

--- a/tests/__snapshots__/markdown-helpers.spec.ts.snap
+++ b/tests/__snapshots__/markdown-helpers.spec.ts.snap
@@ -256,7 +256,7 @@ exports[`markdown-helpers > rawTypeToTypeInformation() > should map a nested com
 exports[`markdown-helpers > rawTypeToTypeInformation() > should map a primitive types correctly 1`] = `
 {
   "collection": false,
-  "type": "Boolean",
+  "type": "boolean",
 }
 `;
 

--- a/tests/markdown-helpers.spec.ts
+++ b/tests/markdown-helpers.spec.ts
@@ -391,8 +391,41 @@ def fn():
   });
 
   describe('rawTypeToTypeInformation()', () => {
+    it('should throw if a primitive type is not lowercase', () => {
+      expect(() =>
+        expect(rawTypeToTypeInformation('Boolean', '', null)),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Use lowercase "boolean" instead of "Boolean" for a primitive type]`,
+      );
+      expect(() =>
+        expect(rawTypeToTypeInformation('Promise<Boolean>', '', null)),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Use lowercase "boolean" instead of "Boolean" for a primitive type]`,
+      );
+      expect(() =>
+        expect(rawTypeToTypeInformation('String', '', null)),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Use lowercase "string" instead of "String" for a primitive type]`,
+      );
+      expect(() =>
+        expect(rawTypeToTypeInformation('Promise<String>', '', null)),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Use lowercase "string" instead of "String" for a primitive type]`,
+      );
+      expect(() =>
+        expect(rawTypeToTypeInformation('Number', '', null)),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Use lowercase "number" instead of "Number" for a primitive type]`,
+      );
+      expect(() =>
+        expect(rawTypeToTypeInformation('Promise<Number>', '', null)),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Use lowercase "number" instead of "Number" for a primitive type]`,
+      );
+    });
+
     it('should map a primitive types correctly', () => {
-      expect(rawTypeToTypeInformation('Boolean', '', null)).toMatchSnapshot();
+      expect(rawTypeToTypeInformation('boolean', '', null)).toMatchSnapshot();
     });
 
     it('should map an unknown types correctly', () => {
@@ -550,12 +583,12 @@ foo`),
         type: 'Integer',
       });
 
-      const stringTokens = getTokens(`Returns \`String\` - Returns the WebRTC IP Handling Policy.`);
+      const stringTokens = getTokens(`Returns \`string\` - Returns the WebRTC IP Handling Policy.`);
       const stringRet = extractReturnType(stringTokens);
       expect(stringRet.parsedReturnType).toEqual({
         collection: false,
         possibleValues: null,
-        type: 'String',
+        type: 'string',
       });
     });
 


### PR DESCRIPTION
The docs are inconsistent in type names (90% string, 10% String, similar for number vs Number, etc). The eventual `electron.d.ts` output gets them finally converted to `string` and `number`, but let's throw an error if the titlecase ones are used in the docs to better enforce consistency and avoid user confusion.

A consequence of this change is a lot of types in `electron-api.json` are currently `String`, and they'll all become `string` - I think that should be fine.