### PR TITLE
docs: replace old style guide link with correct new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Options:
 
 We generate a markdown AST for every documentation file and search for
 "Modules", "Classes" and "Structures".  We then use the well documented
-and enforced [Electron docs style guide](https://github.com/electron/electron/blob/main/docs/styleguide.md) to pull the required information
+and enforced [Electron docs style guide](https://github.com/electron/electron/blob/main/docs/development/style-guide.md) to pull the required information
 about methods, properties and events from the generated AST.
 
 For more information you should start your code dive in


### PR DESCRIPTION
This is a simple `README.md` fix to correct the style guide link.

Suggestion: should we link to the hosted style guide on electronjs.org? Or continue linking directly to its Markdown file on GitHub.com?