### PR TITLE
build: remove npx from prepublishOnly script

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "prepublishOnly": "npx yarn build",
+    "prepublishOnly": "yarn build",
     "prettier:check": "prettier --list-different \"src/**/*.{ts,tsx}\"",
     "prettier:write": "prettier --write \"src/**/*.{ts,tsx}\"",
     "test": "tsc --noEmit -p tests && vitest run",


### PR DESCRIPTION
The `npx` prefix in `prepublishOnly` is unnecessary and creates a supply-chain risk during publish.

**Why this is safe to remove:**
- `packageManager: yarn@4.10.3` is set — corepack provides yarn
- `release.yml` runs `yarn install --immutable` before publishing, so yarn is guaranteed present
- `build` just calls `tsc`, which is a devDependency

**Why `npx yarn` is bad here:**
- `yarn` is not a dep, so npx falls through to fetching `yarn@latest` from the registry
- This happens **during `npm publish`** — worst possible place for an uncontrolled registry fetch